### PR TITLE
Dev docker: container to start every component container at once

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,33 @@
 # It includes the docker-compose configurations from the individual components.
 
 #TODO: add docker-compose files for UI and Crawler components
-include:
-  - db/docker-compose.yml
-  #- crawler/docker-compose.yml 
-  - api/docker-compose.yml
-  #- ui/docker-compose.yml 
+
+version: "3.9"
+
+networks:
+  stac_net:
+
+services:
+  db:
+    extends:
+      file: db/docker-compose.yml
+      service: database
+    networks: [stac_net]
+
+  #crawler:
+  #  extends:
+  #    file: crawler/docker-compose.yml
+  #    service: crawler
+  #  networks: [stac_net]
+
+  api:
+    extends:
+      file: api/docker-compose.yml
+      service: api
+    networks: [stac_net]
+
+  #ui:
+  #  extends:
+  #    file: ui/docker-compose.yml
+  #    service: ui
+  #  networks: [stac_net] 


### PR DESCRIPTION
This PR deals with the docker-compose that starts every component. The compose doesn't start the component directly. it starts only the docker-compose from every component. The effect is the same, but now it makes sense to test the containers from every component since exactly tose are the ones that are opened by the new docker-compose.

The components for CRAWLER and UI are only commented since those components don't have docker contains in `dev` yet. When added to the project the comments can be removed